### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ config.status
 *.a
 *.riscv
 *.map
+build/
+*.cache/


### PR DESCRIPTION
Libgloss was being marked as having untracked content when used as a submodule in chipyard, as the build and cache directories were not in the .gitignore.