### PR TITLE
Support passing command-line arguments from fesvr

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -66,15 +66,19 @@ libgloss_c_srcs := \
 
 libgloss_asm_srcs := \
 	misc/crt0.S \
+	misc/crtmain.S \
+	misc/crtmain-argv.S \
 	misc/init.S
 
 libgloss_hdrs := \
 	$(wildcard $(srcdir)/include/*.h) \
+	$(wildcard $(srcdir)/misc/*.h) \
 	$(wildcard $(srcdir)/libc/stdio/*.h)
 
 specs_newlib := $(srcdir)/util/htif.specs
 specs_nano := $(srcdir)/util/htif_nano.specs
 specs_wrap := $(srcdir)/util/htif_wrap.specs
+specs_argv := $(srcdir)/util/htif_argv.specs
 
 libgloss_lds := $(srcdir)/util/htif.ld
 
@@ -83,6 +87,7 @@ libgloss_data := \
 	$(specs_newlib) \
 	$(specs_nano) \
 	$(specs_wrap) \
+	$(specs_argv) \
 	$(libgloss_lds)
 
 libgloss_CFLAGS := $(CFLAGS) -fno-common -fno-builtin -mcmodel=medany
@@ -153,8 +158,13 @@ hello_src := $(srcdir)/tests/hello.c
 hello_bin_newlib := hello.riscv
 hello_bin_nano := hello.nano.riscv
 hello_bin_pico := hello.pico.riscv
-hello_bins := $(hello_bin_newlib) $(hello_bin_nano) $(hello_bin_pico)
+hello_bin_argv := hello.argv.riscv
 
+hello_bins := \
+	$(hello_bin_newlib) \
+	$(hello_bin_nano) \
+	$(hello_bin_pico) \
+	$(hello_bin_argv)
 
 # NOTE: htif.ld must be symlinked to the current working directory to
 # bypass a spec file limitation that causes gcc to search only the
@@ -180,6 +190,11 @@ $(hello_bin_nano): $(hello_src) $(libgloss_lib) $(specs_nano) htif.ld
 # with more compact alternatives implemented by libgloss_htif
 $(hello_bin_pico): $(hello_src) $(libgloss_lib) $(specs_nano) $(specs_wrap) htif.ld
 	$(CC) $(CFLAGS) -specs=$(specs_nano) -specs=$(specs_wrap) $(LDFLAGS) -Wl,-Map=$@.map -o $@ $<
+	$(SIZE) $@
+
+# Demonstrate support for passing command-line arguments from fesvr
+$(hello_bin_argv): $(hello_src) $(libgloss_lib) $(specs_nano) $(specs_argv) htif.ld
+	$(CC) $(CFLAGS) -specs=$(specs_nano) -specs=$(specs_argv) $(LDFLAGS) -Wl,-Map=$@.map -o $@ $<
 	$(SIZE) $@
 
 .PHONY: check

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Spec File | Description
 [`htif.specs`](util/htif.ld) | Link with newlib
 [`htif_nano.specs`](util/htif_nano.specs) | Link with newlib-nano
 [`htif_wrap.specs`](util/htif_wrap.specs) | Switch to minimal stdio implementation
+[`htif_argv.specs`](util/htif_argv.specs) | Retrieve `argv` from fesvr
 
     $ riscv64-unknown-elf-gcc -O2 -specs=htif.specs -o hello tests/hello.c
 
@@ -58,6 +59,15 @@ This depends on the `--wrap` feature of GNU ld and is intended to be
 used in conjuction with the other newlib spec files.
 
     $ riscv64-unknown-elf-gcc -O2 -specs=htif_nano.specs -specs=htif_wrap.specs -o hello tests/hello.c
+
+`htif_argv.specs` adds extra initialization code to retrieve
+command-line arguments from the frontend server.  The program will exit
+with an error (typically `ENOMEM`) if the number or length of the
+argument strings exceeds the fixed buffer size set by `ARG_MAX`.
+If this feature is omitted, `argv` defaults to a static array with no
+arguments.
+
+    $ riscv64-unknown-elf-gcc -O2 -specs=htif_nano.specs -specs=htif_argv.specs -o hello tests/hello.c
 
 ### Local usage
 

--- a/include/htif.h
+++ b/include/htif.h
@@ -12,7 +12,7 @@ extern volatile uint64_t fromhost;
 #define HTIF_CMD_MASK       0xff
 #define HTIF_PAYLOAD_MASK   ((1UL << HTIF_CMD_SHIFT) - 1)
 
-#if __riscv_xlen != 64
+#if __riscv_xlen == 64
 #define HTIF_TOHOST(dev, cmd, payload) ( \
     (((uint64_t)(dev) & HTIF_DEV_MASK) << HTIF_DEV_SHIFT) | \
     (((uint64_t)(cmd) & HTIF_CMD_MASK) << HTIF_CMD_SHIFT) | \
@@ -23,6 +23,6 @@ extern volatile uint64_t fromhost;
     (((dev) || (cmd)) ? (__builtin_trap(), 0) : (payload))
 #endif
 
-extern void htif_syscall(uintptr_t arg);
+extern long htif_syscall(uint64_t, uint64_t, uint64_t, unsigned long);
 
 #endif /* _CHIPYARD_HTIF_H */

--- a/include/spinlock.h
+++ b/include/spinlock.h
@@ -12,7 +12,9 @@ typedef struct {
 static inline void spin_lock(spinlock_t *lock)
 {
     do {
-        while (atomic_read(&lock->lock));
+#ifdef __riscv_atomic
+        while (atomic_load(&lock->lock));
+#endif
     } while (atomic_swap_acquire(&lock->lock, -1));
 }
 

--- a/include/syscall.h
+++ b/include/syscall.h
@@ -1,11 +1,6 @@
 #ifndef _CHIPYARD_SYSCALL_H
 #define _CHIPYARD_SYSCALL_H
 
-#include <stddef.h>
-#include <sys/types.h>
-
-#include "htif.h"
-
 /* Frontend system calls supported by fesvr */
 #define SYS_getcwd 17
 #define SYS_fcntl 25
@@ -30,27 +25,21 @@
 #define SYS_getmainvars 2011
 
 
-#define __SYSCALL_NARGS_X(a,b,c,d,e,f,g,...) g
-#define __SYSCALL_NARGS(...) \
-    __SYSCALL_NARGS_X(__VA_ARGS__,6,5,4,3,2,1,0,)
+#ifndef __ASSEMBLY__
 
-#define __SYSCALL_CONCAT_X(a, b) a ## b
-#define __SYSCALL_CONCAT(a, b) __SYSCALL_CONCAT_X(a, b)
+#include <stddef.h>
+#include <sys/types.h>
 
-#define __SYSCALL(n, ...) \
-    __SYSCALL_CONCAT(__syscall, __SYSCALL_NARGS(__VA_ARGS__))(n, __VA_ARGS__)
+#include "htif.h"
 
-static inline uintptr_t __syscall3(uint64_t num, uint64_t arg0, uint64_t arg1, uint64_t arg2)
-{
-    volatile uint64_t buf[8];
-    buf[0] = num;
-    buf[1] = arg0;
-    buf[2] = arg1;
-    buf[3] = arg2;
-    htif_syscall((uintptr_t)buf);
-    return buf[0];
-}
+#define SYSCALL1(n, a0) \
+    htif_syscall((a0), 0, 0, (n))
 
+#define SYSCALL2(n, a0, a1) \
+    htif_syscall((a0), (a1), 0, (n))
+
+#define SYSCALL3(n, a0, a1, a2) \
+    htif_syscall((a0), (a1), (a2), (n))
 
 struct stat;
 struct timespec;
@@ -73,7 +62,7 @@ extern int nanosleep(const struct timespec *, struct timespec *);
 extern int _getpid(void);
 extern int _fork(void);
 extern int _execve(const char *, char *const [], char *const []);
-extern void _exit(int);
+extern void _exit(int) __attribute__ ((noreturn));
 extern int _wait(int *);
 extern int _kill(int, int);
 extern char *_getcwd(char *, size_t);
@@ -91,5 +80,7 @@ extern int _ftime(struct timeb *);
 extern int _utime(const char *, const struct utimbuf *);
 extern long _sysconf(int);
 extern int _isatty(int);
+
+#endif /* !__ASSEMBLY__ */
 
 #endif /* _CHIPYARD_SYSCALL_H */

--- a/misc/asm.h
+++ b/misc/asm.h
@@ -1,0 +1,38 @@
+#ifndef _CHIPYARD_ASM_H
+#define _CHIPYARD_ASM_H
+
+#if __riscv_xlen == 64
+#define LREG ld
+#define SREG sd
+#define REGBYTES 8
+#else
+#define LREG lw
+#define SREG sw
+#define REGBYTES 4
+#endif
+
+
+#ifdef __ASSEMBLY__
+
+    /* Signal barrier release */
+    .macro BARRIER_PASS flag
+    li t0, -1
+    fence w, w
+    sw t0, \flag, t1
+    .endm
+
+    /* Wait at barrier */
+    .altmacro
+    .macro BARRIER_WAIT flag
+    LOCAL L1, L2
+L1:
+    auipc t1, %pcrel_hi(\flag)
+L2:
+    lw t0, %pcrel_lo(L1)(t1)
+    beqz t0, L2
+    fence r, r
+    .endm
+
+#endif /* __ASSEMBLY__ */
+
+#endif /* _CHIPYARD_ASM_H */

--- a/misc/crt0.S
+++ b/misc/crt0.S
@@ -1,14 +1,5 @@
+#include "asm.h"
 #include "encoding.h"
-
-#if __riscv_xlen == 64
-# define LREG ld
-# define SREG sd
-# define REGBYTES 8
-#else
-# define LREG lw
-# define SREG sw
-# define REGBYTES 4
-#endif
 
     .section .text.init
     .global _start
@@ -121,32 +112,15 @@ _start:
 
     /* Skip global initialization if not the designated boot hart */
     la t0, __boot_hart
-    la s1, __boot_sync
-    bne s0, t0, 1f
+    bne s0, t0, _start_secondary
 
     /* Call global constructors */
     la a0, __libc_fini_array
     call atexit
     call __libc_init_array
 
-    /* Set __boot_sync flag */
-    li t0, -1
-    sw t0, (s1)
-
-    .macro enter func
-    li a0, 1    /* argc = 1 */
-    la a1, argv /* argv = { "chipyard", NULL } */
-    la a2, envp /* envp = { NULL } */
-    call \func
-    tail exit
-    .endm
-
-    enter main
-
-1:  /* Synchronize secondary harts */
-    lw t0, (s1)
-    beqz t0, 1b
-    enter __main
+    /* Call main function */
+    tail _start_main
 
     .cfi_endproc
 
@@ -236,18 +210,3 @@ trap_entry:
     LREG x2, 2*REGBYTES(sp)
 
     mret
-
-
-    .section .rodata
-    .align 3
-argv:
-    .dc.a name
-envp:
-    .dc.a 0
-name:
-    .asciz "chipyard"
-
-    .section .data
-    .align 2
-__boot_sync:
-    .word 0

--- a/misc/crtmain-argv.S
+++ b/misc/crtmain-argv.S
@@ -1,0 +1,59 @@
+#include "asm.h"
+#include "syscall.h"
+
+/* Maximum number of command-line arguments */
+#ifdef ARG_MAX
+#if ARG_MAX <= 0
+#error "ARG_MAX must be greater than zero"
+#endif
+#else
+#define ARG_MAX 256
+#endif
+
+    .section .text.init
+
+    .global _start_main_argv
+    .type _start_main_argv, @function
+_start_main_argv:
+    /* Retrieve argument vector from frontend server */
+    addi sp, sp, -(ARG_MAX*8)
+    li a3, SYS_getmainvars
+    li a1, (ARG_MAX*8)
+    mv a0, sp
+    call htif_syscall
+    bnez a0, 1f
+
+    lw a0, 0(sp)        /* argc = buf[0] */
+    addi a1, sp, 8      /* argv = buf + 1 */
+    sw a0, argc, t0
+    SREG a1, argv, t0
+
+    BARRIER_PASS __boot_sync
+
+    LREG a2, environ    /* envp */
+    call main
+1:
+    tail exit
+
+
+    .global _start_secondary_argv
+    .type _start_secondary_argv, @function
+_start_secondary_argv:
+    /* Synchronize secondary harts */
+    BARRIER_WAIT __boot_sync
+
+    lw a0, argc
+    LREG a1, argv
+    LREG a2, environ
+    call __main
+    tail exit
+
+
+    .bss
+    .align 3
+argv:
+    .dc.a 0
+argc:
+    .word 0
+__boot_sync:
+    .word 0

--- a/misc/crtmain.S
+++ b/misc/crtmain.S
@@ -1,0 +1,38 @@
+#include "asm.h"
+
+    .section .text.init
+
+    .macro ENTER func
+    /* Default to empty argument vector */
+    li a0, 1            /* argc = 1 */
+    la a1, argv         /* argv = { "", NULL } */
+    LREG a2, environ    /* envp */
+    call \func
+    tail exit
+    .endm
+
+    .global _start_main
+    .type _start_main, @function
+_start_main:
+    BARRIER_PASS __boot_sync
+    ENTER main
+
+    .global _start_secondary
+    .type _start_secondary, @function
+_start_secondary:
+    /* Synchronize secondary harts */
+    BARRIER_WAIT __boot_sync
+    ENTER __main
+
+
+    .section .rodata
+    .align 3
+argv:
+    .dc.a name
+    .dc.a 0
+name:
+    .asciz "chipyard"
+
+    .bss
+__boot_sync:
+    .word 0

--- a/misc/htif.c
+++ b/misc/htif.c
@@ -1,5 +1,6 @@
 #include <stdint.h>
 
+#include "atomic.h"
 #include "spinlock.h"
 #include "htif.h"
 
@@ -20,10 +21,12 @@ long htif_syscall(uint64_t a0, uint64_t a1, uint64_t a2, unsigned long n)
 
     sc = HTIF_TOHOST(0, 0, (uintptr_t)&buf);
     spin_lock(&htif_lock);
+    wmb();
     tohost = sc;
     while (fromhost == 0);
     fromhost = 0;
     spin_unlock(&htif_lock);
 
+    rmb();
     return buf[0];
 }

--- a/sys/write.c
+++ b/sys/write.c
@@ -5,5 +5,5 @@
 
 ssize_t _write(int fd, const void *ptr, size_t len)
 {
-    return __SYSCALL(SYS_write, fd, (uintptr_t)ptr, len);
+    return SYSCALL3(SYS_write, fd, (uintptr_t)ptr, len);
 }

--- a/util/htif_argv.specs
+++ b/util/htif_argv.specs
@@ -1,0 +1,7 @@
+%rename link htif_argv_link
+
+# Add code to retrieve argument vector from frontend server
+*link:
+%(htif_argv_link) \
+    --defsym=_start_main=_start_main_argv \
+    --defsym=_start_secondary=_start_secondary_argv


### PR DESCRIPTION
This enables command-line arguments to be passed from the frontend server by linking in optional code with `htif_argv.specs`.  If this feature is omitted, `argv` defaults to a static array with no arguments (the original behavior).