### PR TITLE
Zero BSS segment

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -153,53 +153,42 @@ install: $(libgloss_install)
 # Test programs
 #
 
+check_bins := # test binaries
+
+# $(1): output file
+# $(2): source files
+# $(3): spec files
+define check
+check_bins += $(1)
+
+$(1): LDFLAGS += -L $$(builddir)
+$(1): $(2) $$(libgloss_lib) $$(libgloss_lds) $(3)
+	$$(CC) $$(CFLAGS) $(foreach f,$(3),-specs=$(f)) $$(LDFLAGS) \
+		-T $$(libgloss_lds) -Wl,-Map=$$@.map -o $$@ $(2)
+	$$(SIZE) $$@
+endef
+
 hello_src := $(srcdir)/tests/hello.c
-
-hello_bin_newlib := hello.riscv
-hello_bin_nano := hello.nano.riscv
-hello_bin_pico := hello.pico.riscv
-hello_bin_argv := hello.argv.riscv
-
-hello_bins := \
-	$(hello_bin_newlib) \
-	$(hello_bin_nano) \
-	$(hello_bin_pico) \
-	$(hello_bin_argv)
-
-# NOTE: htif.ld must be symlinked to the current working directory to
-# bypass a spec file limitation that causes gcc to search only the
-# default library path for the linker script.
-htif.ld: $(libgloss_lds)
-	ln -s $< $@
-
-LDFLAGS += -L $(builddir)
 
 # Manual equivalent:
 # 	$(CC) $(CFLAGS) -mcmodel=medany -nostdlib -nostartfiles -T htif.ld \
 # 		hello.c -Wl,--start-group -lc -lgloss_htif -Wl,--end-group -lgcc
 #
-$(hello_bin_newlib): $(hello_src) $(libgloss_lib) $(specs_newlib) htif.ld
-	$(CC) $(CFLAGS) -specs=$(specs_newlib) $(LDFLAGS) -Wl,-Map=$@.map -o $@ $<
-	$(SIZE) $@
+$(eval $(call check,hello.riscv,$(hello_src),$(specs_newlib)))
 
-$(hello_bin_nano): $(hello_src) $(libgloss_lib) $(specs_nano) htif.ld
-	$(CC) $(CFLAGS) -specs=$(specs_nano) $(LDFLAGS) -Wl,-Map=$@.map -o $@ $<
-	$(SIZE) $@
+# Demonstrate use of newlib-nano
+$(eval $(call check,hello.nano.riscv,$(hello_src),$(specs_nano)))
 
 # Demonstrate using GNU ld's --wrap feature to replace newlib functions
 # with more compact alternatives implemented by libgloss_htif
-$(hello_bin_pico): $(hello_src) $(libgloss_lib) $(specs_nano) $(specs_wrap) htif.ld
-	$(CC) $(CFLAGS) -specs=$(specs_nano) -specs=$(specs_wrap) $(LDFLAGS) -Wl,-Map=$@.map -o $@ $<
-	$(SIZE) $@
+$(eval $(call check,hello.pico.riscv,$(hello_src),$(specs_nano) $(specs_wrap)))
 
 # Demonstrate support for passing command-line arguments from fesvr
-$(hello_bin_argv): $(hello_src) $(libgloss_lib) $(specs_nano) $(specs_argv) htif.ld
-	$(CC) $(CFLAGS) -specs=$(specs_nano) -specs=$(specs_argv) $(LDFLAGS) -Wl,-Map=$@.map -o $@ $<
-	$(SIZE) $@
+$(eval $(call check,hello.argv.riscv,$(hello_src),$(specs_nano) $(specs_argv)))
+
 
 .PHONY: check
-check: $(hello_bins)
-
+check: $(check_bins)
 
 .PHONY: clean
 clean:

--- a/misc/crt0.S
+++ b/misc/crt0.S
@@ -114,6 +114,16 @@ _start:
     la t0, __boot_hart
     bne s0, t0, _start_secondary
 
+    /* Zero BSS segment */
+    la t0, __bss_start
+    la t1, __bss_end
+    bgeu t0, t1, 2f
+1:
+    SREG zero, (t0)
+    addi t0, t0, REGBYTES
+    bltu t0, t1, 1b
+2:
+
     /* Call global constructors */
     la a0, __libc_fini_array
     call atexit

--- a/util/htif.ld
+++ b/util/htif.ld
@@ -101,11 +101,13 @@ SECTIONS
     PROVIDE (_edata = .);
 
     .bss : ALIGN (8) {
+        PROVIDE_HIDDEN (__bss_start = .);
         *(.sbss .sbss.*)
         *(.gnu.linkonce.sb.*)
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
+        PROVIDE_HIDDEN (__bss_end = .);
     }
 
     . = ALIGN (8);


### PR DESCRIPTION
Explicitly zero the `.bss` section to be on the safe side.

This also deduplicates the Makefile rules that build the test binaries, as well as fixing a subtle bug where the wrong linker script was potentially selected by the compiler.  Since the `%s` sequence in the spec string searches the current working directory last, if a copy of `htif.ld` was already installed in the default linker search path, it was prioritized over the symlink to the local source.  Explicitly setting the `-T` option avoids this.