### PR TITLE
Fix enable-multilib manual matching

### DIFF
--- a/configure
+++ b/configure
@@ -2748,7 +2748,7 @@ if test "${enable_multilib+set}" = set; then :
   *) :
     for multilib in $enableval ; do
             case "$multilib" in #(
-  rv32?*-?*|rv64?*-?*) :
+  rv32?*/?*|rv64?*/?*) :
      ;; #(
   *) :
 


### PR DESCRIPTION
The previous regex matched on dash which resulted in the argument parsing being inconsistent with the README e.g. you needed to pass `rv32i-ilp32` instead of `rv32i/ilp32`

If you try to use the `-` symbol to match though, there's a failure later on with the makefile not splitting the `arch` and `abi` correctly since that's done along `/`.

Relevant issue: https://github.com/ucb-bar/chipyard/issues/1188