### PR TITLE
Fix handling of manual arguments for --enable-multilib

### DIFF
--- a/configure
+++ b/configure
@@ -2748,16 +2748,16 @@ if test "${enable_multilib+set}" = set; then :
   *) :
     for multilib in $enableval ; do
             case "$multilib" in #(
-  rv32?*-?*|rv64?*-?*) :
+  rv32?*/?*|rv64?*/?*) :
      ;; #(
   *) :
 
                 { $as_echo "$as_me:${as_lineno-$LINENO}: result: unknown" >&5
 $as_echo "unknown" >&6; }
-                as_fn_error $? "illegal march-mabi value: ${multilib}" "$LINENO" 5
-                multilib="$enableval" ;;
+                as_fn_error $? "illegal march-mabi value: ${multilib}" "$LINENO" 5 ;;
 esac
-            done ;;
+            done ;
+            multilib="$enableval" ;;
 esac
 else
   multilib="`$CC -print-multi-lib | sed '/.*;@march=\(.*\)@mabi=\(.*\).*/{s//\1\/\2/;H;};$!d;x;s/\n/ /g'`"

--- a/configure.ac
+++ b/configure.ac
@@ -20,11 +20,11 @@ AC_ARG_ENABLE([multilib],
         [yes], [multilib="rv32i/ilp32 rv32iac/ilp32 rv32im/ilp32 rv32imac/ilp32 rv32imafc/ilp32f rv64imac/lp64 rv64imafdc/lp64d"],
         [no], [multilib=""],
         [for multilib in $enableval ; do
-            AS_CASE(["$multilib"], [rv32?*-?*|rv64?*-?*], [], [
+            AS_CASE(["$multilib"], [rv32?*/?*|rv64?*/?*], [], [
                 AC_MSG_RESULT([unknown])
-                AC_MSG_ERROR([illegal march-mabi value: ${multilib}])
-                multilib="$enableval"])
-            done])],
+                AC_MSG_ERROR([illegal march-mabi value: ${multilib}])])
+            done
+            multilib="$enableval"])],
     [multilib="`$CC -print-multi-lib | sed '/.*;@march=\(.*\)@mabi=\(.*\).*/{s//\1\/\2/;H;};$!d;x;s/\n/ /g'`"])
 
 AS_IF([test "x$multilib" != x],


### PR DESCRIPTION
Supersedes #9.  Thanks to @michael-etzkorn for the initial fix.

This also fixes the nested `AS_CASE` construct so the `multilib` list is set correctly after validation.