### PR TITLE
ADD: improve startup and linker script

### DIFF
--- a/misc/asm.h
+++ b/misc/asm.h
@@ -11,28 +11,4 @@
 #define REGBYTES 4
 #endif
 
-
-#ifdef __ASSEMBLY__
-
-    /* Signal barrier release */
-    .macro BARRIER_PASS flag
-    li t0, -1
-    fence w, w
-    sw t0, \flag, t1
-    .endm
-
-    /* Wait at barrier */
-    .altmacro
-    .macro BARRIER_WAIT flag
-    LOCAL L1, L2
-L1:
-    auipc t1, %pcrel_hi(\flag)
-L2:
-    lw t0, %pcrel_lo(L1)(t1)
-    beqz t0, L2
-    fence r, r
-    .endm
-
-#endif /* __ASSEMBLY__ */
-
 #endif /* _CHIPYARD_ASM_H */

--- a/misc/crt0.S
+++ b/misc/crt0.S
@@ -1,222 +1,267 @@
 #include "asm.h"
 #include "encoding.h"
 
-    .section .text.init
-    .global _start
-    .type _start, @function
+
+.align 4
+.section .text.trap_vector
+.globl trap_vector
+trap_vector:
+  csrw mscratch, sp
+  addi sp, sp, -(32*REGBYTES)
+
+  /* Save trap frame */
+  SREG x1, 1*REGBYTES(sp)
+  csrr x1, mscratch
+  SREG x1, 2*REGBYTES(sp)
+  SREG x3, 3*REGBYTES(sp)
+  SREG x4, 4*REGBYTES(sp)
+  SREG x5, 5*REGBYTES(sp)
+  SREG x6, 6*REGBYTES(sp)
+  SREG x7, 7*REGBYTES(sp)
+  SREG x8, 8*REGBYTES(sp)
+  SREG x9, 9*REGBYTES(sp)
+  SREG x10, 10*REGBYTES(sp)
+  SREG x11, 11*REGBYTES(sp)
+  SREG x12, 12*REGBYTES(sp)
+  SREG x13, 13*REGBYTES(sp)
+  SREG x14, 14*REGBYTES(sp)
+  SREG x15, 15*REGBYTES(sp)
+  SREG x16, 16*REGBYTES(sp)
+  SREG x17, 17*REGBYTES(sp)
+  SREG x18, 18*REGBYTES(sp)
+  SREG x19, 19*REGBYTES(sp)
+  SREG x20, 20*REGBYTES(sp)
+  SREG x21, 21*REGBYTES(sp)
+  SREG x22, 22*REGBYTES(sp)
+  SREG x23, 23*REGBYTES(sp)
+  SREG x24, 24*REGBYTES(sp)
+  SREG x25, 25*REGBYTES(sp)
+  SREG x26, 26*REGBYTES(sp)
+  SREG x27, 27*REGBYTES(sp)
+  SREG x28, 28*REGBYTES(sp)
+  SREG x29, 29*REGBYTES(sp)
+  SREG x30, 30*REGBYTES(sp)
+  SREG x31, 31*REGBYTES(sp)
+
+  /* Invoke higher-level trap handler */
+  csrr a0, mepc
+  csrr a1, mcause
+  csrr a2, mtval
+  mv a3, sp
+  call handle_trap
+  csrw mepc, a0
+
+  /* Remain in M-mode after return */
+  li t0, MSTATUS_MPP
+  csrs mstatus, t0
+
+  LREG x1, 1*REGBYTES(sp)
+  LREG x3, 3*REGBYTES(sp)
+  LREG x4, 4*REGBYTES(sp)
+  LREG x5, 5*REGBYTES(sp)
+  LREG x6, 6*REGBYTES(sp)
+  LREG x7, 7*REGBYTES(sp)
+  LREG x8, 8*REGBYTES(sp)
+  LREG x9, 9*REGBYTES(sp)
+  LREG x10, 10*REGBYTES(sp)
+  LREG x11, 11*REGBYTES(sp)
+  LREG x12, 12*REGBYTES(sp)
+  LREG x13, 13*REGBYTES(sp)
+  LREG x14, 14*REGBYTES(sp)
+  LREG x15, 15*REGBYTES(sp)
+  LREG x16, 16*REGBYTES(sp)
+  LREG x17, 17*REGBYTES(sp)
+  LREG x18, 18*REGBYTES(sp)
+  LREG x19, 19*REGBYTES(sp)
+  LREG x20, 20*REGBYTES(sp)
+  LREG x21, 21*REGBYTES(sp)
+  LREG x22, 22*REGBYTES(sp)
+  LREG x23, 23*REGBYTES(sp)
+  LREG x24, 24*REGBYTES(sp)
+  LREG x25, 25*REGBYTES(sp)
+  LREG x26, 26*REGBYTES(sp)
+  LREG x27, 27*REGBYTES(sp)
+  LREG x28, 28*REGBYTES(sp)
+  LREG x29, 29*REGBYTES(sp)
+  LREG x30, 30*REGBYTES(sp)
+  LREG x31, 31*REGBYTES(sp)
+  /* Restore sp last */
+  LREG x2, 2*REGBYTES(sp)
+
+  mret
+
+
+.align 4
+.section .text.init
+.global _start
+.type _start, @function
 _start:
     .cfi_startproc
 
-    li x1, 0
-    li x2, 0
-    li x3, 0
-    li x4, 0
-    li x5, 0
-    li x6, 0
-    li x7, 0
-    li x8, 0
-    li x9, 0
-    li x10, 0
-    li x11, 0
-    li x12, 0
-    li x13, 0
-    li x14, 0
-    li x15, 0
-    li x16, 0
-    li x17, 0
-    li x18, 0
-    li x19, 0
-    li x20, 0
-    li x21, 0
-    li x22, 0
-    li x23, 0
-    li x24, 0
-    li x25, 0
-    li x26, 0
-    li x27, 0
-    li x28, 0
-    li x29, 0
-    li x30, 0
-    li x31, 0
+  /* initialize registers */
+  li x1, 0
+  li x2, 0
+  li x3, 0
+  li x4, 0
+  li x5, 0
+  li x6, 0
+  li x7, 0
+  li x8, 0
+  li x9, 0
+  li x10, 0
+  li x11, 0
+  li x12, 0
+  li x13, 0
+  li x14, 0
+  li x15, 0
+  li x16, 0
+  li x17, 0
+  li x18, 0
+  li x19, 0
+  li x20, 0
+  li x21, 0
+  li x22, 0
+  li x23, 0
+  li x24, 0
+  li x25, 0
+  li x26, 0
+  li x27, 0
+  li x28, 0
+  li x29, 0
+  li x30, 0
+  li x31, 0
 
-    li t0, (MSTATUS_FS | MSTATUS_XS | MSTATUS_VS)
-    csrs mstatus, t0
+  li t0, (MSTATUS_FS | MSTATUS_XS | MSTATUS_VS)
+  csrs mstatus, t0
 
 #ifdef __riscv_flen
-    /* Initialize FPU if present */
-    la t0, 1f
-    csrw mtvec, t0
+  /* Initialize FPU if present */
+  la t0, fpu_init_exit
+  csrw mtvec, t0
 
-    fscsr zero
-    fmv.s.x f0,  zero
-    fmv.s.x f1,  zero
-    fmv.s.x f2,  zero
-    fmv.s.x f3,  zero
-    fmv.s.x f4,  zero
-    fmv.s.x f5,  zero
-    fmv.s.x f6,  zero
-    fmv.s.x f7,  zero
-    fmv.s.x f8,  zero
-    fmv.s.x f9,  zero
-    fmv.s.x f10, zero
-    fmv.s.x f11, zero
-    fmv.s.x f12, zero
-    fmv.s.x f13, zero
-    fmv.s.x f14, zero
-    fmv.s.x f15, zero
-    fmv.s.x f16, zero
-    fmv.s.x f17, zero
-    fmv.s.x f18, zero
-    fmv.s.x f19, zero
-    fmv.s.x f20, zero
-    fmv.s.x f21, zero
-    fmv.s.x f22, zero
-    fmv.s.x f23, zero
-    fmv.s.x f24, zero
-    fmv.s.x f25, zero
-    fmv.s.x f26, zero
-    fmv.s.x f27, zero
-    fmv.s.x f28, zero
-    fmv.s.x f29, zero
-    fmv.s.x f30, zero
-    fmv.s.x f31, zero
-1:
+  fscsr zero
+  fmv.s.x f0,  zero
+  fmv.s.x f1,  zero
+  fmv.s.x f2,  zero
+  fmv.s.x f3,  zero
+  fmv.s.x f4,  zero
+  fmv.s.x f5,  zero
+  fmv.s.x f6,  zero
+  fmv.s.x f7,  zero
+  fmv.s.x f8,  zero
+  fmv.s.x f9,  zero
+  fmv.s.x f10, zero
+  fmv.s.x f11, zero
+  fmv.s.x f12, zero
+  fmv.s.x f13, zero
+  fmv.s.x f14, zero
+  fmv.s.x f15, zero
+  fmv.s.x f16, zero
+  fmv.s.x f17, zero
+  fmv.s.x f18, zero
+  fmv.s.x f19, zero
+  fmv.s.x f20, zero
+  fmv.s.x f21, zero
+  fmv.s.x f22, zero
+  fmv.s.x f23, zero
+  fmv.s.x f24, zero
+  fmv.s.x f25, zero
+  fmv.s.x f26, zero
+  fmv.s.x f27, zero
+  fmv.s.x f28, zero
+  fmv.s.x f29, zero
+  fmv.s.x f30, zero
+  fmv.s.x f31, zero
+fpu_init_exit:
 #endif
 
-    /* Initialize global pointer; disable relaxation to avoid relaxing
-       the address calculation to "addi gp, gp, 0" */
-    .option push
-    .option norelax
-    la gp, __global_pointer$
-    .option pop
+  /* Initialize global pointer; disable relaxation to avoid relaxing
+      the address calculation to "addi gp, gp, 0" */
+  .option push
+  .option norelax
+  la gp, __global_pointer$
+  .option pop
 
-    /* Initialize thread pointer */
-    csrr s0, mhartid
-    lui t0, %hi(__stack_shift)
-    addi t0, t0, %lo(__stack_shift)
-    la tp, __stack_start
-    sll t0, s0, t0
-    add tp, tp, t0
+  /* Initialize thread pointer */
+  csrr s0, mhartid
+  la t0, __stack_shift
+  la tp, __stack_start
+  sll t0, s0, t0
+  add tp, tp, t0
 
-    /* Initialize stack pointer */
-    lui t0, %hi(__stack_size)
-    addi t0, t0, %lo(__stack_size)
-    add sp, tp, t0
+  /* Initialize stack pointer */
+  la t0, __stack_size
+  add sp, tp, t0
 
-    /* Initialize trap vector */
-    la t0, trap_entry
-    csrw mtvec, t0
+  /* Initialize trap vector */
+  la t0, trap_vector
+  csrw mtvec, t0
 
-    /* Initialize TLS */
-    call __init_tls
+tls_init_entry:
+  /* Initialize TLS */
+  mv t0, tp
+  la t1, __tdata_start
+  la t2, __tdata_end
 
-    /* Skip global initialization if not the designated boot hart */
-    la t0, __boot_hart
-    bne s0, t0, _start_secondary
+  # see if:
+  # - tdata section is already at correct location?
+  # - tdata section is of size 0?
+  beq t0, t1, tls_init_exit
+  bge t1, t2, tls_init_exit
 
-    /* Zero BSS segment */
-    la t0, __bss_start
-    la t1, __bss_end
-    bgeu t0, t1, 2f
-1:
-    SREG zero, (t0)
-    addi t0, t0, REGBYTES
-    bltu t0, t1, 1b
-2:
+tls_init_loop:
+  LREG  t3, 0(t0)
+  SREG  t3, 0(tp)
+  addi  t0, t0, REGBYTES
+  addi  t1, t1, REGBYTES
+  blt   t1, t2, tls_init_loop
 
-    /* Call global constructors */
-    la a0, __libc_fini_array
-    call atexit
-    call __libc_init_array
+tls_init_exit:
 
-    /* Call main function */
-    tail _start_main
+  /* Skip global initialization if not the designated boot hart */
+  la t0, __boot_hart
+  bne s0, t0, _start_secondary
 
-    .cfi_endproc
+data_init_entry:
+  /* Copy data from non-volatile memory to runtime location */
+  la t0, __data_load_start
+  la t1, __data_start
+  la t2, __data_end
 
+  # see if:
+  # - data section is already at correct location?
+  # - data section is of size 0?
+  beq t0, t1, data_init_exit
+  bge t1, t2, data_init_exit
 
-    .align 2
-trap_entry:
-    csrw mscratch, sp
-    addi sp, sp, -(32*REGBYTES)
+data_init_loop:
+  LREG  t3, 0(t0)
+  SREG  t3, 0(t1)
+  addi  t0, t0, REGBYTES
+  addi  t1, t1, REGBYTES
+  blt   t1, t2, data_init_loop
 
-    /* Save trap frame */
-    SREG x1, 1*REGBYTES(sp)
-    csrr x1, mscratch
-    SREG x1, 2*REGBYTES(sp)
-    SREG x3, 3*REGBYTES(sp)
-    SREG x4, 4*REGBYTES(sp)
-    SREG x5, 5*REGBYTES(sp)
-    SREG x6, 6*REGBYTES(sp)
-    SREG x7, 7*REGBYTES(sp)
-    SREG x8, 8*REGBYTES(sp)
-    SREG x9, 9*REGBYTES(sp)
-    SREG x10, 10*REGBYTES(sp)
-    SREG x11, 11*REGBYTES(sp)
-    SREG x12, 12*REGBYTES(sp)
-    SREG x13, 13*REGBYTES(sp)
-    SREG x14, 14*REGBYTES(sp)
-    SREG x15, 15*REGBYTES(sp)
-    SREG x16, 16*REGBYTES(sp)
-    SREG x17, 17*REGBYTES(sp)
-    SREG x18, 18*REGBYTES(sp)
-    SREG x19, 19*REGBYTES(sp)
-    SREG x20, 20*REGBYTES(sp)
-    SREG x21, 21*REGBYTES(sp)
-    SREG x22, 22*REGBYTES(sp)
-    SREG x23, 23*REGBYTES(sp)
-    SREG x24, 24*REGBYTES(sp)
-    SREG x25, 25*REGBYTES(sp)
-    SREG x26, 26*REGBYTES(sp)
-    SREG x27, 27*REGBYTES(sp)
-    SREG x28, 28*REGBYTES(sp)
-    SREG x29, 29*REGBYTES(sp)
-    SREG x30, 30*REGBYTES(sp)
-    SREG x31, 31*REGBYTES(sp)
+data_init_exit:
 
-    /* Invoke higher-level trap handler */
-    csrr a0, mepc
-    csrr a1, mcause
-    csrr a2, mtval
-    mv a3, sp
-    call handle_trap
-    csrw mepc, a0
+bss_init_entry:
+  /* Zero BSS segment */
+  la t0, __bss_start
+  la t1, __bss_end
+  bgeu t0, t1, bss_init_exit
 
-    /* Remain in M-mode after return */
-    li t0, MSTATUS_MPP
-    csrs mstatus, t0
+bss_init_loop:
+  SREG zero, (t0)
+  addi t0, t0, REGBYTES
+  bltu t0, t1, bss_init_loop
 
-    LREG x1, 1*REGBYTES(sp)
-    LREG x3, 3*REGBYTES(sp)
-    LREG x4, 4*REGBYTES(sp)
-    LREG x5, 5*REGBYTES(sp)
-    LREG x6, 6*REGBYTES(sp)
-    LREG x7, 7*REGBYTES(sp)
-    LREG x8, 8*REGBYTES(sp)
-    LREG x9, 9*REGBYTES(sp)
-    LREG x10, 10*REGBYTES(sp)
-    LREG x11, 11*REGBYTES(sp)
-    LREG x12, 12*REGBYTES(sp)
-    LREG x13, 13*REGBYTES(sp)
-    LREG x14, 14*REGBYTES(sp)
-    LREG x15, 15*REGBYTES(sp)
-    LREG x16, 16*REGBYTES(sp)
-    LREG x17, 17*REGBYTES(sp)
-    LREG x18, 18*REGBYTES(sp)
-    LREG x19, 19*REGBYTES(sp)
-    LREG x20, 20*REGBYTES(sp)
-    LREG x21, 21*REGBYTES(sp)
-    LREG x22, 22*REGBYTES(sp)
-    LREG x23, 23*REGBYTES(sp)
-    LREG x24, 24*REGBYTES(sp)
-    LREG x25, 25*REGBYTES(sp)
-    LREG x26, 26*REGBYTES(sp)
-    LREG x27, 27*REGBYTES(sp)
-    LREG x28, 28*REGBYTES(sp)
-    LREG x29, 29*REGBYTES(sp)
-    LREG x30, 30*REGBYTES(sp)
-    LREG x31, 31*REGBYTES(sp)
-    /* Restore sp last */
-    LREG x2, 2*REGBYTES(sp)
+bss_init_exit:
 
-    mret
+  /* Call global constructors */
+  la a0, __libc_fini_array
+  call atexit
+  call __libc_init_array
+
+  /* Call primary hart boot function */
+  tail _start_primary
+
+  .cfi_endproc

--- a/misc/crtmain-argv.S
+++ b/misc/crtmain-argv.S
@@ -10,50 +10,48 @@
 #define ARG_MAX 256
 #endif
 
-    .section .text.init
 
-    .global _start_main_argv
-    .type _start_main_argv, @function
-_start_main_argv:
-    /* Retrieve argument vector from frontend server */
-    addi sp, sp, -(ARG_MAX*8)
-    li a3, SYS_getmainvars
-    li a1, (ARG_MAX*8)
-    mv a0, sp
-    call htif_syscall
-    bnez a0, 1f
+.section .text.init
+.global _start_primary_argv
+.type _start_primary_argv, @function
+_start_primary_argv:
+  /* Retrieve argument vector from frontend server */
+  addi sp, sp, -(ARG_MAX*8)
+  li a3, SYS_getmainvars
+  li a1, (ARG_MAX*8)
+  mv a0, sp
+  call htif_syscall
+  bnez a0, 1f
 
-    lw a0, 0(sp)        /* argc = buf[0] */
-    addi a1, sp, 8      /* argv = buf + 1 */
-    sw a0, argc, t0
-    SREG a1, argv, t0
+  lw a0, 0(sp)        /* argc = buf[0] */
+  addi a1, sp, 8      /* argv = buf + 1 */
+  sw a0, argc, t0
+  SREG a1, argv, t0
 
-    BARRIER_PASS __boot_sync
-
-    LREG a2, environ    /* envp */
-    call main
+  LREG a2, environ    /* envp */
+  call main
 1:
-    tail exit
+  tail exit
+  j infinite_loop
 
 
-    .global _start_secondary_argv
-    .type _start_secondary_argv, @function
+.global _start_secondary_argv
+.type _start_secondary_argv, @function
 _start_secondary_argv:
-    /* Synchronize secondary harts */
-    BARRIER_WAIT __boot_sync
+  lw a0, argc
+  LREG a1, argv
+  LREG a2, environ
+  call __main
+  tail exit
+  j infinite_loop
 
-    lw a0, argc
-    LREG a1, argv
-    LREG a2, environ
-    call __main
-    tail exit
+infinite_loop:
+  j infinite_loop
 
 
-    .bss
-    .align 3
+.bss
+.align 3
 argv:
-    .dc.a 0
+  .dc.a 0
 argc:
-    .word 0
-__boot_sync:
-    .word 0
+  .word 0

--- a/misc/crtmain.S
+++ b/misc/crtmain.S
@@ -1,38 +1,40 @@
 #include "asm.h"
 
-    .section .text.init
 
-    .macro ENTER func
-    /* Default to empty argument vector */
-    li a0, 1            /* argc = 1 */
-    la a1, argv         /* argv = { "", NULL } */
-    LREG a2, environ    /* envp */
-    call \func
-    tail exit
-    .endm
+.section .text.init
+.global _start_primary
+.type _start_primary, @function
+_start_primary:
+  /* Call main function */
+  li a0, 1            /* argc = 1 */
+  la a1, argv         /* argv = { "", NULL } */
+  LREG a2, environ    /* envp */
+  
+  call main
+  tail exit
+  j infinite_loop
 
-    .global _start_main
-    .type _start_main, @function
-_start_main:
-    BARRIER_PASS __boot_sync
-    ENTER main
 
-    .global _start_secondary
-    .type _start_secondary, @function
+.global _start_secondary
+.type _start_secondary, @function
 _start_secondary:
-    /* Synchronize secondary harts */
-    BARRIER_WAIT __boot_sync
-    ENTER __main
+  /* Call __main function */
+  li a0, 1            /* argc = 1 */
+  la a1, argv         /* argv = { "", NULL } */
+  LREG a2, environ    /* envp */
+  
+  call __main
+  tail exit
+  j infinite_loop
+
+infinite_loop:
+  j infinite_loop
 
 
-    .section .rodata
-    .align 3
+.section .rodata
+.align 3
 argv:
-    .dc.a name
-    .dc.a 0
+  .dc.a name
+  .dc.a 0
 name:
-    .asciz "chipyard"
-
-    .bss
-__boot_sync:
-    .word 0
+  .asciz "chipyard"

--- a/util/htif.ld
+++ b/util/htif.ld
@@ -1,131 +1,207 @@
-OUTPUT_ARCH ("riscv")
-ENTRY (_start)
+/**
+  * @file htif.ld
+  * @brief Linker script to describe the memory layout of the RISC-V platform that supports HTIF interface.
+  * It defines following symbols, which code can use without definition:
+  *   __boot_hart
+  *   __stack_size
+  *   __heap_size
+  *   __text_start
+  *   __text_load_start
+  *   __text_end
+  *   __data_start
+  *   __data_load_start
+  *   __preinit_array_start
+  *   __preinit_array_end
+  *   __init_array_start
+  *   __init_array_end
+  *   __fini_array_start
+  *   __fini_array_end
+  *   __tdata_start
+  *   __tdata_end
+  *   __tdata_size
+  *   __data_end
+  *   __tbss_start
+  *   __tbss_end
+  *   __tbss_size
+  *   __bss_start
+  *   __bss_end
+  *   __end
+  *   __heap_start
+  *   __heap_end
+  *   __stack_start
+  *   __sp
+  *   __stack_end
+  *   __stack_shift
+  *
+  */
 
-SECTIONS
-{
-    . = 0x80000000;
+OUTPUT_ARCH("riscv")
 
-    /* Keep under a power of 2 to reserve space for TCB */
-    PROVIDE (__stack_size_min = 24K);
+/* Program entry point */
+ENTRY(_start)
 
-    .text : {
-        *(.text.init)
-        *(.text.unlikely .text.unlikely.*)
-        *(.text.startup .text.startup.*)
-        *(.text .text.*)
-        *(.gnu.linkonce.t.*)
-    }
-    PROVIDE (_etext = .);
+MEMORY {
+  DRAM     (rwx): ORIGIN = 0x80000000, LENGTH = 16384M
+}
 
-    /* Static Thread Local Storage template */
+SECTIONS {
+  /* Default boot hart */
+  PROVIDE(__boot_hart = 0);
+
+  /* Default stack size */
+  __stack_size = DEFINED(__stack_size) ? __stack_size : 24K;
+  PROVIDE(__stack_size = __stack_size);
+
+  /* Default heap size */
+  __heap_size = DEFINED(__heap_size) ? __heap_size : 128K;
+  PROVIDE(__heap_size = __heap_size);
+  
+  /* Section containing the program */
+  .text : ALIGN(4) {
+    PROVIDE(__text_start = .);
+    *(.text.init)
+    *(.text.trap_vector)
+    *(.text.unlikely .text.unlikely.*)
+    *(.text.startup .text.startup.*)
+    *(.text .text.*)
+    *(.gnu.linkonce.t.*)
+    PROVIDE(__text_end = .);
+  }> DRAM
+  PROVIDE(__text_load_start = LOADADDR(.text));
+  PROVIDE(_etext = .);  /* Deprecated, supplied here for backward compatibility */
+
+  /* Section containing read-only data */
+  .rodata : {
+    . = ALIGN(4);
+    *(.rodata .rodata.*)
+    *(.gnu.linkonce.r.*)
+    . = ALIGN(8);
+    *(.srodata.cst16)
+    *(.srodata.cst8)
+    *(.srodata.cst4)
+    *(.srodata.cst2)
+    *(.srodata .srodata.*)
+  }> DRAM
+
+  /* Section for initialized data */
+  .data : ALIGN(8) {
+    PROVIDE(__data_start = .);
+    *(.data)
+    *(.gnu.linkonce.d.*)
+  }> DRAM
+  
+  PROVIDE(__data_load_start = LOADADDR(.data));
+
+  .preinit_array : {
+    PROVIDE_HIDDEN(__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN(__preinit_array_end = .);
+  }> DRAM
+  
+  .init_array : {
+    PROVIDE_HIDDEN(__init_array_start = .);
+    KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+    KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .ctors))
+    PROVIDE_HIDDEN(__init_array_end = .);
+  }> DRAM
+
+  .fini_array : {
+    PROVIDE_HIDDEN(__fini_array_start = .);
+    KEEP(*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+    KEEP(*(.fini_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .dtors))
+    PROVIDE_HIDDEN(__fini_array_end = .);
+  }> DRAM
+
+  .ctors : {
+    KEEP(*crtbegin.o(.ctors))
+    KEEP(*crtbegin?.o(.ctors))
+    KEEP(*(EXCLUDE_FILE(*crtend.o *crtend?.o) .ctors))
+    KEEP(*(SORT(.ctors.*)))
+    KEEP(*(.ctors))
+  }> DRAM
+
+  .dtors : {
+    KEEP(*crtbegin.o(.dtors))
+    KEEP(*crtbegin?.o(.dtors))
+    KEEP(*(EXCLUDE_FILE(*crtend.o *crtend?.o) .dtors))
+    KEEP(*(SORT(.dtors.*)))
+    KEEP(*(.dtors))
+  }> DRAM
+
+  /* Section for initialized small data */
+  .sdata : {
+    PROVIDE(__global_pointer$ = . + 0x800);
+    *(.sdata .sdata.*)
+    *(.gnu.linkonce.s.*)
+  }> DRAM
+
+  /* Section for initialized thread-local small data */
     .tdata : {
-        PROVIDE_HIDDEN (__tdata_start = .);
-        *(.tdata .tdata.*)
-        *(.gnu.linkonce.td.*)
-        PROVIDE_HIDDEN (__tdata_end = .);
-    }
-    PROVIDE (__tdata_size = SIZEOF (.tdata));
+    PROVIDE_HIDDEN(__tdata_start = .);
+    *(.tdata .tdata.*)
+    *(.gnu.linkonce.td.*)
+    PROVIDE_HIDDEN(__tdata_end = .);
+    PROVIDE(__data_end = .);
+  }> DRAM
+  PROVIDE(__tdata_size = SIZEOF(.tdata));
 
-    .tbss (NOLOAD) : {
-        PROVIDE_HIDDEN (__tbss_start = .);
-        PROVIDE_HIDDEN (__tbss_offset = ABSOLUTE (__tbss_start - __tdata_start));
-        *(.tbss .tbss.*)
-        *(.gnu.linkonce.tb.*)
-        *(.tcommon)
-        PROVIDE_HIDDEN (__tbss_end = .);
-    }
-    PROVIDE (__tbss_size = SIZEOF (.tbss));
+  /* Section for zero-initialized thread-local uninitialized data */
+  .tbss (NOLOAD) : ALIGN(8) {
+    PROVIDE_HIDDEN(__tbss_start = .);
+    PROVIDE_HIDDEN(__tbss_offset = ABSOLUTE(__tbss_start - __tdata_start));
+    *(.tbss .tbss.*)
+    *(.gnu.linkonce.tb.*)
+    *(.tcommon)
+    PROVIDE_HIDDEN(__tbss_end = .);
+  }> DRAM
+  PROVIDE(__tbss_size = SIZEOF(.tbss));
+  
+  /* Section for uninitialized data */
+  .bss : ALIGN (8) {
+    PROVIDE_HIDDEN(__bss_start = .);
+    *(.sbss .sbss.*)
+    *(.gnu.linkonce.sb.*)
+    *(.bss .bss.*)
+    *(.gnu.linkonce.b.*)
+    *(COMMON)
+    PROVIDE_HIDDEN(__bss_end = .);
+  }> DRAM
 
-    .rodata : {
-        *(.rodata .rodata.*)
-        *(.gnu.linkonce.r.*)
-    }
+  /* Host-Target Interface */
+  .htif : ALIGN(0x40) {
+    *(.htif)
+  }
 
-    .preinit_array : {
-        PROVIDE_HIDDEN (__preinit_array_start = .);
-        KEEP (*(.preinit_array))
-        PROVIDE_HIDDEN (__preinit_array_end = .);
-    }
+  . = ALIGN (8);
+  PROVIDE(__end = .);
+  PROVIDE (_end = .);  /* Deprecated, supplied here for backward compatibility */
 
-    .init_array : {
-        PROVIDE_HIDDEN (__init_array_start = .);
-        KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP (*(.init_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .ctors))
-        PROVIDE_HIDDEN (__init_array_end = .);
-    }
-
-    .fini_array : {
-        PROVIDE_HIDDEN (__fini_array_start = .);
-        KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
-        KEEP (*(.fini_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .dtors))
-        PROVIDE_HIDDEN (__fini_array_end = .);
-    }
-
-    .ctors : {
-        KEEP (*crtbegin.o(.ctors))
-        KEEP (*crtbegin?.o(.ctors))
-        KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o) .ctors))
-        KEEP (*(SORT(.ctors.*)))
-        KEEP (*(.ctors))
-    }
-
-    .dtors : {
-        KEEP (*crtbegin.o(.dtors))
-        KEEP (*crtbegin?.o(.dtors))
-        KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o) .dtors))
-        KEEP (*(SORT(.dtors.*)))
-        KEEP (*(.dtors))
-    }
-
-    /* Host-Target Interface */
-    .htif ALIGN(0x40) : {
-        *(.htif)
-    }
-
-    .data : ALIGN (8) {
-        *(.data)
-        *(.gnu.linkonce.d.*)
-    }
-
-    .sdata : {
-        PROVIDE (__global_pointer$ = . + 0x800);
-        *(.sdata .sdata.*)
-        *(.gnu.linkonce.s.*)
-        *(.srodata.cst16)
-        *(.srodata.cst8)
-        *(.srodata.cst4)
-        *(.srodata.cst2)
-        *(.srodata .srodata.*)
-    }
-
-    PROVIDE (_edata = .);
-
-    .bss : ALIGN (8) {
-        PROVIDE_HIDDEN (__bss_start = .);
-        *(.sbss .sbss.*)
-        *(.gnu.linkonce.sb.*)
-        *(.bss .bss.*)
-        *(.gnu.linkonce.b.*)
-        *(COMMON)
-        PROVIDE_HIDDEN (__bss_end = .);
-    }
-
-    . = ALIGN (8);
-    PROVIDE (_end = .);
-
-    /* Reserve heap space */
-    PROVIDE(__heap_size = 128K);
+  /* Reserve heap space */
+  .heap (NOLOAD) : ALIGN(8) {
+    PROVIDE_HIDDEN(__heap_start = .);
     . += __heap_size;
-    . = ALIGN (4K);
-    PROVIDE (__heap_end = .);
+    . = ALIGN(4K);
+    PROVIDE_HIDDEN(__heap_end = .);
+  }> DRAM
 
-    /* Place Thread Control Block (TCB) at bottom of hart stack */
-    PROVIDE (__tcb_size = __tbss_end - __tdata_start);
-    PROVIDE (__stack_align = MAX (ALIGNOF (.tdata), 0x10));
-    PROVIDE (__stack_start = ALIGN (__stack_align));
-    PROVIDE (__stack_shift = LOG2CEIL( ALIGN (__stack_size_min + __tcb_size, __stack_align)));
-    PROVIDE (__stack_size = 1 << __stack_shift);
+  /* Reserve stack space */
+  .stack (NOLOAD) : ALIGN(16) {
+    PROVIDE_HIDDEN(__stack_start = .);
+    . += __stack_size;
+    PROVIDE(__sp = .);
+    PROVIDE_HIDDEN(__stack_end = .);
+  }> DRAM
 
-    /* Default boot hart */
-    PROVIDE (__boot_hart = 0);
+  PROVIDE (_sp = .);  /* Deprecated, supplied here for backward compatibility */
+
+  PROVIDE(__stack_shift = LOG2CEIL(__stack_size));
+  
+  /* C++ exception handling information is
+   * not useful with our current runtime environment,
+   * and it consumes flash space. Discard it until
+   * we have something that can use it
+   */
+  /DISCARD/ : {
+    *(.eh_frame .eh_frame.*)
+  }
 }

--- a/util/htif_argv.specs
+++ b/util/htif_argv.specs
@@ -3,5 +3,5 @@
 # Add code to retrieve argument vector from frontend server
 *link:
 %(htif_argv_link) \
-    --defsym=_start_main=_start_main_argv \
+    --defsym=_start_primary=_start_primary_argv \
     --defsym=_start_secondary=_start_secondary_argv


### PR DESCRIPTION
This PR improves the following:

- provides a set of standard symbols in the linker script (e.g. `__text_start`, `__text_end`, `__end`, `__sp` etc.)
- reorganizes the startup file to be compatible with real-chip startup files
- improves naming to avoid confusion (`primary` & `secondary` routines, instead of `main` & `secondary`)
- adds inline comments in the startup file and linker scripts
- removes the synchronization between the secondary and primary hart. The synchronization should be handled in the C program context (see `mt-hello.c` in chipyard/tests).

